### PR TITLE
Enable for a single repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ $ find-hearted-contributions [options]
 Options:
   --help     Show help                                                 [boolean]
   --version  Show version number                                       [boolean]
+  --token    GitHub auth token                               [string]
   --in       GitHub organization URL                         [string] [required]
   --by       GitHub username                                 [string] [required]
   --since    timestamp in ISO 8601 format or GitHub issue URL, in which case
@@ -61,9 +62,13 @@ Digging out these hearted items turned out harder than I thought, so I wrote thi
 
 If you find it useful, please share where / how you use it 😊
 
+## Usage
+
+You must pass a GitHub personal authentication token. This project requires the "public_repo" scope for public repositories, "repo" scope for private repositories.
+
 ## Contributing
 
-This is a very early version of something that I hope to become very useful for many maintainers out there. I’m open to any kind of contributions, be it ideas, code improvemetns, tests, or documentation.
+This is a very early version of something that I hope to become very useful for many maintainers out there. I’m open to any kind of contributions, be it ideas, code improvements, tests, or documentation.
 
 Thanks!
 

--- a/bin/find-hearted-contributions.js
+++ b/bin/find-hearted-contributions.js
@@ -14,7 +14,7 @@ var argv = yargs
     type: 'string'
   })
   .option('in', {
-    description: 'GitHub organization URL',
+    description: 'GitHub organization URL, or the repository url',
     demandOption: true,
     type: 'string'
   })

--- a/index.js
+++ b/index.js
@@ -29,8 +29,8 @@ async function findHeartedContributions (options) {
 
   octokit.hook.before('request', () => process.stdout.write('.'))
 
-  if (!/^https:\/\/github\.com\/[^/]+$/.test(options.in)) {
-    throw new TypeError('"in" option must be a GitHub or url (e.g. "https://github.com/octokit"')
+  if (!/^https:\/\/github\.com\/.+$/.test(options.in)) {
+    throw new TypeError('"in" option must be a GitHub repo url (e.g. "https://github.com/octokit"')
   }
 
   const owner = options.in.substr('https://github.com/'.length)
@@ -41,12 +41,18 @@ async function findHeartedContributions (options) {
     issuesAndPullRequestUrls: [],
     commentsUrls: [],
     comments: [],
+    repoOnly: owner.split('/')[1],
     ...options
   }
 
   try {
     state.since = await getLastUpdateTimestamp(state)
-    state.repositories = await getRepositories(state)
+    if (state.repoOnly) {
+      state.owner = state.owner.split('/')[0]
+      state.repositories = [state.repoOnly]
+    } else {
+      state.repositories = await getRepositories(state)
+    }
 
     for (const repositoryName of state.repositories) {
       const issuesAndPullRequestUrls = await getIssuesAndPullRequestsForRepository(state, repositoryName)


### PR DESCRIPTION
This PR enables you to use a single repo in the URL field. Closes #2.

The implementation is not elegant, but it works.

-----
[View rendered README.md](https://github.com/RichardLitt/find-hearted-contributions/blob/feat/repo-only/README.md)